### PR TITLE
JQ-12345 Improve empty object check

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -233,7 +233,9 @@ jQuery.extend( {
 		var name;
 
 		for ( name in obj ) {
-			return false;
+			if ( obj.hasOwnProperty( name ) ) {
+				return false;
+			}
 		}
 		return true;
 	},


### PR DESCRIPTION
$.isEmptyObject will now only return false if properties are not inherited